### PR TITLE
style: use for-each loop in `joutarray`, `joutarraylist` and `joutlinkedlist`

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,8 +345,8 @@ System.out.println();
 ```
 ### ❇️ joutarray = Creates a Java output code of Array
 ```java
-for (int i = 0; i < arr.length; i++) {
-    System.out.println(arr[i]);
+for (final var e : arr) {
+    System.out.println(e);
 }
 ```
 ### ❇️ joutarraylist = Creates a Java output code of ArrayList

--- a/README.md
+++ b/README.md
@@ -363,8 +363,8 @@ for (Map.Entry<String, Integer> entry : map.entrySet()) {
 ```
 ### ❇️ joutlinkedlist = Creates a Java output code of LinkedList
 ```java
-for (int i = 0; i < list.size(); i++) {
-    System.out.println(list.get(i));
+for (final var e : list) {
+    System.out.println(e);
 }
 ```
 ```<!---------------------------------------------------------------------------------> ```

--- a/README.md
+++ b/README.md
@@ -351,8 +351,8 @@ for (final var e : arr) {
 ```
 ### ❇️ joutarraylist = Creates a Java output code of ArrayList
 ```java
-for (int i = 0; i < list.size(); i++) {
-    System.out.println(list.get(i));
+for (final var e : list) {
+    System.out.println(e);
 }
 ```
 ### ❇️ jouthashmap = Creates a Java output code of Hash Map

--- a/README.md
+++ b/README.md
@@ -345,14 +345,14 @@ System.out.println();
 ```
 ### ❇️ joutarray = Creates a Java output code of Array
 ```java
-for (final var e : arr) {
-    System.out.println(e);
+for (final var element : arr) {
+    System.out.println(element);
 }
 ```
 ### ❇️ joutarraylist = Creates a Java output code of ArrayList
 ```java
-for (final var e : list) {
-    System.out.println(e);
+for (final var element : list) {
+    System.out.println(element);
 }
 ```
 ### ❇️ jouthashmap = Creates a Java output code of Hash Map
@@ -363,8 +363,8 @@ for (Map.Entry<String, Integer> entry : map.entrySet()) {
 ```
 ### ❇️ joutlinkedlist = Creates a Java output code of LinkedList
 ```java
-for (final var e : list) {
-    System.out.println(e);
+for (final var element : list) {
+    System.out.println(element);
 }
 ```
 ```<!---------------------------------------------------------------------------------> ```

--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -528,8 +528,8 @@
   "Java Array Output": {
     "prefix": "joutarray",
     "body": [
-      "for (int i = 0; i < arr.length; i++) {",
-      "    System.out.println(arr[i]);",
+      "for (final var e : arr) {",
+      "    System.out.println(e);",
       "}",
       "$0",
     ],

--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -540,8 +540,8 @@
   "Java ArrayList Output": {
     "prefix": "joutarraylist",
     "body": [
-      "for (int i = 0; i < list.size(); i++) {",
-      "    System.out.println(list.get(i));",
+      "for (final var e : list) {",
+      "    System.out.println(e);",
       "}",
       "$0",
     ],

--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -528,8 +528,8 @@
   "Java Array Output": {
     "prefix": "joutarray",
     "body": [
-      "for (final var e : arr) {",
-      "    System.out.println(e);",
+      "for (final var element : arr) {",
+      "    System.out.println(element);",
       "}",
       "$0",
     ],
@@ -540,8 +540,8 @@
   "Java ArrayList Output": {
     "prefix": "joutarraylist",
     "body": [
-      "for (final var e : list) {",
-      "    System.out.println(e);",
+      "for (final var element : list) {",
+      "    System.out.println(element);",
       "}",
       "$0",
     ],
@@ -562,8 +562,8 @@
   "Java LinkedList Output": {
     "prefix": "joutlinkedlist",
     "body": [
-      "for (final var e : list) {",
-      "    System.out.println(e);",
+      "for (final var element : list) {",
+      "    System.out.println(element);",
       "}",
       "$0",
     ],

--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -562,8 +562,8 @@
   "Java LinkedList Output": {
     "prefix": "joutlinkedlist",
     "body": [
-      "for (int i = 0; i < list.size(); i++) {",
-      "    System.out.println(list.get(i));",
+      "for (final var e : list) {",
+      "    System.out.println(e);",
       "}",
       "$0",
     ],


### PR DESCRIPTION
In these cases the _for-each_ loop can be used. Note that in case of `joutlinkedlist` the _old_ approach is inefficient, because time complexity of [`LinkedList.get()`](https://docs.oracle.com/javase/8/docs/api/java/util/LinkedList.html#get-int-) is $O(n)$.