### PR TITLE
style: do not explicilty define the type of `element`

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ for (final var element : list) {
 ```
 ### ❇️ jouthashmap = Creates a Java output code of Hash Map
 ```java
-for (Map.Entry<String, Integer> entry : map.entrySet()) {
+for (final var entry : map.entrySet()) {
     System.out.println(entry.getKey() + entry.getValue());
 }
 ```

--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -551,7 +551,7 @@
   "Java HashMap Output": {
     "prefix": "jouthashmap",
     "body": [
-      "for (Map.Entry<String, Integer> entry : map.entrySet()) {",
+      "for (final var entry : map.entrySet()) {",
       "    System.out.println(entry.getKey() + \" \" + entry.getValue());",
       "}",
       "$0",
@@ -608,7 +608,7 @@
   "Java TreeMap Output": {
     "prefix": "jouttreemap",
     "body": [
-      "for (Map.Entry<String, Integer> entry : map.entrySet()) {",
+      "for (final var entry : map.entrySet()) {",
       "    System.out.println(entry.getKey() + \" \" + entry.getValue());",
       "}",
       "$0",


### PR DESCRIPTION
I think using `final var` makes more sense here, because the code is more _flexible_ (we do not care what types are stored in the `map`).

By the way, having `jouttreemap` and `jouthashmap` seems to be redundant. Does it make sense to _merge_ them into something like `joutmap`?